### PR TITLE
change dwPosition to be equal to dwSampleOffset for cues

### DIFF
--- a/src/WavHandler.js
+++ b/src/WavHandler.js
@@ -37,6 +37,11 @@ export default class WavHandler {
                 })
             }
         }
+
+        for (let i = 0; i < file.cue.points.length; i++) {
+            file.cue.points[i].dwPosition = file.cue.points[i].dwSampleOffset
+        }
+
         const data = file.toDataURI()
         saveAs(data, "export.wav")
     }


### PR DESCRIPTION
Fixes #6 .

When investigating, it seemed the main difference between an export from Morphaweb and REAPER was that the `dwPosition` wasn't set in Morphaweb. This change sets the attribute normally, not sure why wavefile doesn't do it.